### PR TITLE
Problem 332: Tests are failing with "The name 'Blender' does not exist in the current context".

### DIFF
--- a/src/UniformDocs/Program.cs
+++ b/src/UniformDocs/Program.cs
@@ -6,6 +6,7 @@ using UniformDocs.ViewModels.Components;
 using UniformDocs.ViewModels.Design;
 using UniformDocs.ViewModels.HowTo;
 using Starcounter;
+using Starcounter.Advanced;
 
 namespace UniformDocs
 {


### PR DESCRIPTION
Suggested fix for #332.