### PR TITLE
initialize DataTable page in Db.Scope (#348)

### DIFF
--- a/src/UniformDocs/Program.cs
+++ b/src/UniformDocs/Program.cs
@@ -159,9 +159,12 @@ namespace UniformDocs
 
             Handle.GET("/UniformDocs/partial/datatable", () =>
             {
-                var dataTablePage = new DataTablePage();
-                dataTablePage.Init();
-                return dataTablePage;
+                return Db.Scope(() =>
+                {
+                    var dataTablePage = new DataTablePage();
+                    dataTablePage.Init();
+                    return dataTablePage;
+                });
             });
 
             Handle.GET("/UniformDocs/datatable", () => WrapPage<DataTablePage>("/UniformDocs/partial/datatable"));


### PR DESCRIPTION
Because otherwise editing the email address or removing a row triggers an exception.

Fixes: https://github.com/Starcounter/UniformDocs/issues/348