### PR TITLE
Improve flaky dropdown tests, fix Polymer data-binding

### DIFF
--- a/src/UniformDocs/wwwroot/UniformDocs/Components/PaginationPage.html
+++ b/src/UniformDocs/wwwroot/UniformDocs/Components/PaginationPage.html
@@ -14,7 +14,7 @@
                 <code>FETCH</code> to determine how many entries there should be on every page and
                 <code>OFFSET</code> to retrieve the right entries
             </p>
-            <juicy-select slot="uniformdocs/pagination-juicy-select-items-per-page" class="uniformdocs-juicyselect" value="{{model.EntriesPerPage$::change}}" options="{{model.PageEntries}}" text-property="Text" value-property="Amount">
+            <juicy-select slot="uniformdocs/pagination-juicy-select-items-per-page" class="uniformdocs-juicyselect" value="{{model.EntriesPerPage$}}" options="{{model.PageEntries}}" text-property="Text" value-property="Amount">
             </juicy-select>
             <table slot="uniformdocs/pagination-table">
                 <thead>
@@ -33,7 +33,7 @@
                 </tbody>
             </table>
             <input type="range" slot="uniformdocs/pagination-pages" value="{{model.CurrentPage$::change}}" end$="{{model.TotalPages}}" />
-           
+
             <p slot="uniformdocs/pagination-page-number">page {{model.CurrentPage$}} of {{model.TotalPages}}</p>
 
             <github-source-links base="{{model.Html}}"></github-source-links>

--- a/test/UniformDocs.Tests/Test/DatepickerPageTest.cs
+++ b/test/UniformDocs.Tests/Test/DatepickerPageTest.cs
@@ -29,7 +29,7 @@ namespace UniformDocs.Tests.Test
         [Test]
         public void DatepickerPage_SelectDate()
         {
-            WaitUntil(x => _datePicker.YearInput.Displayed);
+            WaitUntil(x => _datePicker.IsLoaded(), $"Expected date picker to be fully loaded");
 
             _datePicker.SelectThroughUniDatePicker("2016-01-01");
 

--- a/test/UniformDocs.Tests/Test/PaginationPageTest.cs
+++ b/test/UniformDocs.Tests/Test/PaginationPageTest.cs
@@ -29,7 +29,7 @@ namespace UniformDocs.Tests.Test
         {
             _paginationPage.ScrollToTheTop();
 
-            WaitUntil(x => _paginationPage.DropDown.Displayed);
+            WaitUntil(x => _paginationPage.DropDown.Displayed, $"Expected DropDown to be Displayed");
             _paginationPage.DropdownSelect("Show 5 items per page");
             Assert.IsTrue(WaitForText(_paginationPage.PaginationInfoLabel, "page 1 of 20", 5));
             Assert.AreEqual(5, _paginationPage.PaginationResult.Count);

--- a/test/UniformDocs.Tests/Ui/DatepickerPage.cs
+++ b/test/UniformDocs.Tests/Ui/DatepickerPage.cs
@@ -31,5 +31,17 @@ namespace UniformDocs.Tests.Ui
             pickerInput.SendKeys(date);
             pickerInput.SendKeys(Keys.Enter);
         }
+        public bool IsLoaded()
+        {
+            try
+            {
+                var page = Driver.FindElement(By.CssSelector("starcounter-include[slot=\"uniformdocs/current\"]"));
+                return page.Displayed && YearInput.Displayed;
+            }
+            catch
+            {
+                return false;
+            }
+        }
     }
 }


### PR DESCRIPTION
Improve date-picker and pagination tests, add descriptions for timeouts


Remove custom notification event, use default called by `.set`, bubbled `<select>`@change event was happening too early, before value was set to proper one. (breaks data-binding in latest Polymer)