### PR TITLE
Problem 395: Improve test error reporting when the app crashes.

### DIFF
--- a/test/UniformDocs.Tests/Test/BaseTest.cs
+++ b/test/UniformDocs.Tests/Test/BaseTest.cs
@@ -20,6 +20,7 @@ namespace UniformDocs.Tests.Test
         private List<string> _browsersToRun = new List<string>();
         private ResultState LastOutcome;
         private string LastOutcomeMessage;
+        private static readonly string appName = "UniformDocs";
 
         public BaseTest(Config.Browser browser)
         {
@@ -60,6 +61,11 @@ namespace UniformDocs.Tests.Test
         [TearDown]
         public void TearDown()
         {
+            if (!(RestApiHelper.CheckAppRunning(appName).Result))
+            {
+                Assert.Inconclusive($"The tested app {appName} crushed. The possible reason: {RestApiHelper.GetLatestLogEntry().Result}");
+            }
+
             if (LastOutcome == null || TestContext.CurrentContext.Result.Outcome != ResultState.Success)
             {
                 //this class has single driver session for all test methods

--- a/test/UniformDocs.Tests/Test/ProgressBarTest.cs
+++ b/test/UniformDocs.Tests/Test/ProgressBarTest.cs
@@ -12,6 +12,7 @@ namespace UniformDocs.Tests.Test
     {
         private ProgressBarPage _progressBarPage;
         private MainPage _mainPage;
+        private static readonly string appName = "UniformDocs";
 
         public ProgressBarTest(Config.Browser browser) : base(browser)
         {
@@ -20,6 +21,11 @@ namespace UniformDocs.Tests.Test
         [SetUp]
         public void SetUp()
         {
+            if (!(RestApiHelper.CheckAppRunning(appName).Result))
+            {
+                Assert.Inconclusive($"The tested app {appName} is not running");
+            }
+
             _mainPage = new MainPage(Driver).GoToMainPage();
             _progressBarPage = _mainPage.GoToProgressBarPage();
         }

--- a/test/UniformDocs.Tests/UniformDocs.Tests.csproj
+++ b/test/UniformDocs.Tests/UniformDocs.Tests.csproj
@@ -49,6 +49,7 @@
     <Reference Include="Starcounter.Internal, Version=2.0.0.0, Culture=neutral, PublicKeyToken=d2df1e81d0ca3abf, processorArchitecture=MSIL" />
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="WebDriver, Version=3.11.2.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Selenium.WebDriver.3.11.2\lib\net45\WebDriver.dll</HintPath>
     </Reference>
@@ -113,6 +114,7 @@
     <Compile Include="Ui\TextareaPage.cs" />
     <Compile Include="Ui\TextPage.cs" />
     <Compile Include="Utilities\Config.cs" />
+    <Compile Include="Utilities\RestApiHelper.cs" />
     <Compile Include="Utilities\WebDriverManager.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/test/UniformDocs.Tests/Utilities/RestApiHelper.cs
+++ b/test/UniformDocs.Tests/Utilities/RestApiHelper.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Starcounter.Internal;
+
+namespace UniformDocs.Tests.Utilities
+{
+    public static class RestApiHelper
+    {
+        private static readonly ushort InternalPort = StarcounterEnvironment.Default.SystemHttpPort;
+        private const string InternalHost = "127.0.0.1";
+
+        public class DatabaseApplicationsJson
+        {
+            public IEnumerable<App> Items { get; set; }
+        }
+
+        public class Log
+        {
+            public IEnumerable<LogEntry> LogEntries { get; set; }
+        }
+
+        public class App
+        {
+            public string DisplayName { get; set; }
+        }
+
+        public class LogEntry
+        {
+            public string Message { get; set; }
+        }
+
+        public static async Task<bool> CheckAppRunning(string appName)
+        {
+            HttpResponseMessage response = await new HttpClient().GetAsync($"http://{InternalHost}:{InternalPort}/api/admin/databases/default/applications");
+
+            if (response.IsSuccessStatusCode)
+            {
+                var runningAppsString = await response.Content.ReadAsStringAsync();
+                var runningApps = JsonConvert.DeserializeObject<DatabaseApplicationsJson>(runningAppsString);
+
+                foreach (var app in runningApps.Items)
+                {
+                    if (app.DisplayName == appName)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        public static async Task<string> GetLatestLogEntry()
+        {
+            string Parameters = "debug=false&error=true&maxitems=1&notice=false&source=&warning=true";
+
+            HttpResponseMessage response = await new HttpClient().GetAsync($"http://{InternalHost}:{InternalPort}/api/admin/log?{Parameters}");
+
+            if (response.IsSuccessStatusCode)
+            {
+                var latestLogEntryString = await response.Content.ReadAsStringAsync();
+
+                var latestLogEntry = JsonConvert.DeserializeObject<Log>(latestLogEntryString);
+
+                if (latestLogEntry.LogEntries.FirstOrDefault() != null && !string.IsNullOrEmpty(latestLogEntry.LogEntries.First().Message))
+                {
+                    return latestLogEntry.LogEntries.First().Message;
+                }
+            }
+
+            return String.Empty;
+        }
+    }
+}

--- a/test/UniformDocs.Tests/packages.config
+++ b/test/UniformDocs.Tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net461" />
   <package id="NUnit" version="3.10.1" targetFramework="net461" />
   <package id="NUnit.ConsoleRunner" version="3.6.1" targetFramework="net461" />


### PR DESCRIPTION
**Problem #395:**
>My proposal is like this:
>
>1. Before each test, check if the app is running. If not, quit with an error that the app is not running
>2. After each test, check if the app is running. If not, quit with an error that the app crashed with the last error messages from the log.

**Solution:**
1. Was added helper class for getting needed kind-of `administration` info through the REST API.
2. For the first iteration (to discuss current implementation) were added invocations of the `Assert.Inconclusive` method with required message inside.

**Tests:**
1. `D:\git\UniformDocs>test --test="UniformDocs.Tests.Test.ProgressBarTest"` without any other actions - passed.
2. `D:\git\UniformDocs>test --test="UniformDocs.Tests.Test.ProgressBarTest"` and stopping the `UniformDocs` app after 10 seconds - didn't passed.

**Screenshots:**
![tests4](https://user-images.githubusercontent.com/17431807/54018311-6150d580-4199-11e9-8a1d-32fc0d0eccd9.PNG)
![tests1](https://user-images.githubusercontent.com/17431807/54018442-b4c32380-4199-11e9-9fad-ffbdc8de07b5.PNG)

**Questions:**
1. @warpech maybe we should use `--stoponerror` command instead of throwing the exception in the current test using `Assert.Inconclusive`? Or from other hand this will break the module structure pattern  of the unit-tests?
2. Maybe you have an idea about another test case? (i already got almost similar result starting tests in VS)
3. For now i don't have the solid answer why the **first error** (on the first screenshot) talking about `null reference exception` in the `[OneTimeTearDown]` method and how bad this for us.